### PR TITLE
Adapt spacy into update of benepar

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -2029,7 +2029,7 @@
                 "from benepar.spacy_plugin import BeneparComponent",
                 "",
                 "nlp = spacy.load('en')",
-                "nlp.add_pipe(BeneparComponent('benepar_en'))",
+                "nlp.add_pipe(BeneparComponent('benepar_en3'))",
                 "doc = nlp('The time for action is now. It is never too late to do something.')",
                 "sent = list(doc.sents)[0]",
                 "print(sent._.parse_string)",


### PR DESCRIPTION
I can't download 'benepar_en' model.
Like "https://pypi.org/project/benepar/", benepar library recommend to use 'benepar_en3' model now.
(And I can download it on benepar library whose version is "0.2.0".)

So, I think it is better to fix 'benepar' into 'benepar_en3'.

<!--- Provide a general summary of your changes in the title. -->
Adapt spacy into update of benepar

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Spacy don't adapt into new benepar version.
So, I adapted it into benepar "0.2.0". (esp. model file change)

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
change to the documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
